### PR TITLE
Gracefully handle missing weather fields (temperature, humidity, pressure)

### DIFF
--- a/bin/user/purpleair.py
+++ b/bin/user/purpleair.py
@@ -151,7 +151,7 @@ def collect_data(session, hostname, timeout, now_ts = None):
         missed.append('pressure')
 
     if missed:
-        loginf('sensor didn\'t report field(s): %s' % missed.join(','))
+        loginf('sensor didn\'t report field(s): %s' % ','.join(missed))
 
     # for each concentration counter grab the average of the A and B channels and push into the record
     for key in ['pm1_0_cf_1', 'pm1_0_atm', 'pm2_5_cf_1', 'pm2_5_atm', 'pm10_0_cf_1', 'pm10_0_atm']:

--- a/bin/user/purpleair.py
+++ b/bin/user/purpleair.py
@@ -114,6 +114,11 @@ def loginf(msg):
 def logerr(msg):
     logmsg(syslog.LOG_ERR, msg)
 
+def get(d, key, missings):
+    v = d.get(key, None)
+    if v is None:
+        missings.append(key)
+    return v, missings
 
 def collect_data(session, hostname, timeout, now_ts = None):
     # used for testing
@@ -132,18 +137,21 @@ def collect_data(session, hostname, timeout, now_ts = None):
     j = r.json()
 
     # put items into record
-    if j.has_key('current_temp_f'):
-        record['purple_temperature'] = j['current_temp_f']
-    if j.has_key('current_humidity'):
-        record['purple_humidity'] = j['current_humidity']
-    if j.has_key('current_dewpoint_f'):
-        record['purple_dewpoint'] = j['current_dewpoint_f']
+    missed = []
+    record['purple_temperature'], missed = get(j, 'current_temp_f', missed)
+    record['purple_humidity'], missed = get(j, 'current_humidity', missed)
+    record['purple_dewpoint'], missed = get(j, 'current_dewpoint_f', missed)
 
     # convert pressure from mbar to US units.
     # FIXME: is there a cleaner way to do this
     if j.has_key('pressure'):
         pressure, units, group = weewx.units.convertStd((j['pressure'], 'mbar', 'group_pressure'), weewx.US)
         record['purple_pressure'] = pressure
+    else:
+        missed.append('pressure')
+
+    if missed:
+        loginf('sensor didn't report field(s): %s' % missed.join(','))
 
     # for each concentration counter grab the average of the A and B channels and push into the record
     for key in ['pm1_0_cf_1', 'pm1_0_atm', 'pm2_5_cf_1', 'pm2_5_atm', 'pm10_0_cf_1', 'pm10_0_atm']:

--- a/bin/user/purpleair.py
+++ b/bin/user/purpleair.py
@@ -132,14 +132,18 @@ def collect_data(session, hostname, timeout, now_ts = None):
     j = r.json()
 
     # put items into record
-    record['purple_temperature'] = j['current_temp_f']
-    record['purple_humidity'] = j['current_humidity']
-    record['purple_dewpoint'] = j['current_dewpoint_f']
+    if j.has_key('current_temp_f'):
+        record['purple_temperature'] = j['current_temp_f']
+    if j.has_key('current_humidity'):
+        record['purple_humidity'] = j['current_humidity']
+    if j.has_key('current_dewpoint_f'):
+        record['purple_dewpoint'] = j['current_dewpoint_f']
 
     # convert pressure from mbar to US units.
     # FIXME: is there a cleaner way to do this
-    pressure, units, group = weewx.units.convertStd((j['pressure'], 'mbar', 'group_pressure'), weewx.US)
-    record['purple_pressure'] = pressure
+    if j.has_key('pressure'):
+        pressure, units, group = weewx.units.convertStd((j['pressure'], 'mbar', 'group_pressure'), weewx.US)
+        record['purple_pressure'] = pressure
 
     # for each concentration counter grab the average of the A and B channels and push into the record
     for key in ['pm1_0_cf_1', 'pm1_0_atm', 'pm2_5_cf_1', 'pm2_5_atm', 'pm10_0_cf_1', 'pm10_0_atm']:

--- a/bin/user/purpleair.py
+++ b/bin/user/purpleair.py
@@ -151,7 +151,7 @@ def collect_data(session, hostname, timeout, now_ts = None):
         missed.append('pressure')
 
     if missed:
-        loginf('sensor didn't report field(s): %s' % missed.join(','))
+        loginf('sensor didn\'t report field(s): %s' % missed.join(','))
 
     # for each concentration counter grab the average of the A and B channels and push into the record
     for key in ['pm1_0_cf_1', 'pm1_0_atm', 'pm2_5_cf_1', 'pm2_5_atm', 'pm10_0_cf_1', 'pm10_0_atm']:


### PR DESCRIPTION
PurpleAir sensor reports occasionally miss temperature, humidity and pressure items yet still continue to report air quality measurements. It is important to capture the air quality measurements even if the other measurements are missing. This patch makes it possible to do so. Without it, the collection task will throw an exception and fail to log any data.

If these fields are missing, they will now be logged at INFO level, with a message similar to the following:

    purpleair: sensor didn't report field(s): temperature,humidity,pressure
