### PR TITLE
Add ability to specify port number for communicating to Purple Air station

### DIFF
--- a/.#readme.md
+++ b/.#readme.md
@@ -1,1 +1,0 @@
-root@www.jfroot.com.11919:1558111742

--- a/.#readme.md
+++ b/.#readme.md
@@ -1,0 +1,1 @@
+root@www.jfroot.com.11919:1558111742

--- a/changelog
+++ b/changelog
@@ -1,4 +1,4 @@
-.3.1 20190524
+0.3.1 20190524
 * Add in ability to specify a port number, default being 80
 
 0.3 20180116

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+.3.1 20190524
+* Add in ability to specify a port number, default being 80
+
 0.3 20180116
 * remove cmon reference from installer
 

--- a/install.py
+++ b/install.py
@@ -17,7 +17,8 @@ class PurpleAirMonitorInstaller(ExtensionInstaller):
             config={
                 'PurpleAirMonitor': {
                     'data_binding': 'purpleair_binding',
-                    'hostname': 'purple-air' },
+                    'hostname': 'purple-air',
+                    'port': '80'},
                 'DataBindings': {
                     'purpleair_binding': {
                         'database': 'purpleair_sqlite',

--- a/readme.md
+++ b/readme.md
@@ -34,14 +34,15 @@ saved at the archive interval of the station.
 
 This will install the purpleair.py extension into the weewx/user/
 directory.  It will also add the necessary data bindings, hostname,
-database, and service configuration to the weewx.conf configuration
-file.
+port number, database, and service configuration to the weewx.conf
+configuration file.
 
 Something like the following:
 
     [PurpleAirMonitor]
         data_binding = purpleair_binding
         hostname = purple-air.example.com
+        port = 80
     [DataBindings]
         [[purpleair_binding]]
             database = purpleair_sqlite


### PR DESCRIPTION
Sometimes, an end-user finds it necessary to put the purple air sensor behind something that does port forwarding and port translation across a network address translator (NAT), with the weewx-running computer located outside of the NAT. In this case, the NAT device may translate a request to (made up global address) "1.2.3.4 port 1000" to local device (made up local address for Purple Air device ) "192.168.1.101 port 80" because that same NAT device may already be sending port 80 requests to another machine inside the NAT, or the end user may believe it's unwise to open up port 80 on port forwarding NAT for any reason. To handle this case, having weewx-purpleair being able to specify the port number, so the request goes to "http://1.2.3.4:1000/json" is very handy. These changes add this capability.