### PR TITLE
Ported to Python 3 and WeeWX V4.x

### DIFF
--- a/bin/user/purpleair.py
+++ b/bin/user/purpleair.py
@@ -82,7 +82,7 @@ weewx.units.USUnits['group_concentration'] = 'microgram_per_meter_cubed'
 weewx.units.MetricUnits['group_concentration'] = 'microgram_per_meter_cubed'
 weewx.units.MetricWXUnits['group_concentration'] = 'microgram_per_meter_cubed'
 weewx.units.default_unit_format_dict['microgram_per_meter_cubed'] = '%.3f'
-weewx.units.default_unit_label_dict['microgram_per_meter_cubed']  = u'µg/m³',
+weewx.units.default_unit_label_dict['microgram_per_meter_cubed']  = u'µg/m³'
 
 # assign types of units to specific measurements
 weewx.units.obs_group_dict['purple_temperature'] = 'group_temperature'

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+0.4 20210498
+* Ported to Python 3 and WeeWX V4.x. -tk
+
 0.3.1 20190524
 * Add in ability to specify a port number, default being 80
 

--- a/install.py
+++ b/install.py
@@ -1,6 +1,6 @@
 # Copyright 2018 Ken Baker
 
-from setup import ExtensionInstaller
+from weecfg.extension import ExtensionInstaller
 
 def loader():
     return PurpleAirMonitorInstaller()
@@ -8,7 +8,7 @@ def loader():
 class PurpleAirMonitorInstaller(ExtensionInstaller):
     def __init__(self):
         super(PurpleAirMonitorInstaller, self).__init__(
-            version="0.1",
+            version="0.4",
             name='purpleair',
             description='Collect Purple Air air quality data.',
             author="Kenneth Baker",

--- a/readme.md
+++ b/readme.md
@@ -63,11 +63,11 @@ the purpleair.sdb file.
 ### Examples:
 * The current value:
 
-```$latest('purpleair_binding').pm2_5_cf_1.formatted```
+```$latest('purpleair_binding').pm2_5_cf_1```
     
 * The maximum value today:
 
-```$day('purpleair_binding').pm2_5_cf_1.max.formatted```
+```$day('purpleair_binding').pm2_5_cf_1.max```
 
 * The time today when the maximum value occurred:
 


### PR DESCRIPTION
Hi, Ken

I ported your extension to Python 3 and WeeWX V4.x. I've only tested it by running the extension driver directly, not as part of WeeWX.

One note: your extension does a poll of the PA sensor in the main thread. This is generally not a good idea, as it will kill weewxd if the HTTP request fails. Better to set it up in a separate thread, and monitor a queue. 

See the wiki article [multi-threaded service](https://github.com/weewx/weewx/wiki/multi-threaded-service) for a general idea of how to do this.

Let me know if you have any questions.