### PR TITLE
Fall back to DateTime when response_date is absent (fixes #31)

### DIFF
--- a/bin/user/purpleair.py
+++ b/bin/user/purpleair.py
@@ -188,7 +188,13 @@ def collect_data(session, hostname, port, timeout, api_key):
         last_seen = datetime.datetime.utcfromtimestamp(j['last_seen'])
     else:
         j = r.json()
-        last_seen = datetime.datetime.utcfromtimestamp(j['response_date'])
+        if 'response_date' in j:
+            last_seen = datetime.datetime.utcfromtimestamp(j['response_date'])
+        elif 'DateTime' in j:
+            last_seen = datetime.datetime.strptime(j['DateTime'], "%Y/%m/%dT%H:%M:%Sz")
+        else:
+            loginf("sensor didn't report time field")
+            last_seen = None
 
     record = dict()
     record['dateTime'] = int(time.time())
@@ -223,7 +229,7 @@ def collect_data(session, hostname, port, timeout, api_key):
         loginf("sensor didn't report field(s): %s" % ','.join(missed))
 
     # when last seen field is older than 10 minutes do not return any particle data
-    if datetime.datetime.utcnow() - last_seen < valid_timeout:
+    if last_seen is not None and datetime.datetime.utcnow() - last_seen < valid_timeout:
         # for each concentration counter grab the average of the A and B channels and push into the record
 
         # NEWLY are values from PA website json with dot so it´s necessary to remap it


### PR DESCRIPTION
## Summary
- Some PurpleAir firmware/hardware combinations (e.g. hardware 3.0 / firmware 7.04) report a `DateTime` field but not `response_date`, so `collect_data()` raised `KeyError: 'response_date'` and silently skipped every record.
- Fall back to parsing the device's `DateTime` (UTC, format `%Y/%m/%dT%H:%M:%Sz`) when `response_date` is missing, and log + skip cleanly if neither field is present.
- Guards the existing staleness check so a `None` `last_seen` no longer crashes.

This is the patch validated by @splobsterman in the [issue thread](https://github.com/bakerkj/weewx-purpleair/issues/31#issuecomment-…) — they confirmed it got their sensor writing to `purpleair.sdb` on 2026-06-02.

## Test plan
- [ ] Confirm a sensor returning only `DateTime` (hw 3.0 / fw 7.04) now writes records.
- [ ] Confirm a sensor returning `response_date` (the original path) still works unchanged.
- [ ] Confirm the PurpleAir website path (`is_data_from_purpleair_website`) is untouched.

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)