### PR TITLE
Release 0.10 — require weewx 4.0, use built-in concentration unit

### DIFF
--- a/bin/user/purpleair.py
+++ b/bin/user/purpleair.py
@@ -70,7 +70,7 @@ import weeutil.weeutil
 from weewx.engine import StdService
 import weewx.units
 
-WEEWX_PURPLEAIR_VERSION = "0.9"
+WEEWX_PURPLEAIR_VERSION = "0.10"
 
 PY3 = sys.version_info[0] == 3
 

--- a/bin/user/purpleair.py
+++ b/bin/user/purpleair.py
@@ -80,16 +80,15 @@ else:
     binary_type = str
 
 
-if weewx.__version__ < "3":
-    raise weewx.UnsupportedFeature("weewx 3 is required, found %s" %
-                                   weewx.__version__)
+if weewx.__version__ < "4":
+    raise weewx.UnsupportedFeature(
+        "weewx 4.0 is required (built-in group_concentration / "
+        "microgram_per_meter_cubed), found %s" % weewx.__version__)
 
-# set up appropriate units
-weewx.units.USUnits['group_concentration'] = 'microgram_per_meter_cubed'
-weewx.units.MetricUnits['group_concentration'] = 'microgram_per_meter_cubed'
-weewx.units.MetricWXUnits['group_concentration'] = 'microgram_per_meter_cubed'
-weewx.units.default_unit_format_dict['microgram_per_meter_cubed'] = '%.3f'
-weewx.units.default_unit_label_dict['microgram_per_meter_cubed']  = u'µg/m³'
+# weewx 4.0+ ships group_concentration / microgram_per_meter_cubed and
+# the unsuffixed pm1_0/pm2_5/pm10_0 → group_concentration mappings, plus
+# the default StringFormat and Label. Only the purpleair-specific suffix
+# variants (`_cf_1`, `_atm`) need registration here.
 
 # assign types of units to specific measurements
 weewx.units.obs_group_dict['purple_temperature'] = 'group_temperature'

--- a/changelog
+++ b/changelog
@@ -1,3 +1,8 @@
+0.10 20260613
+* require weewx 4.0; use its built-in concentration unit (drops the
+  redundant USUnits / MetricUnits / default_unit_format_dict /
+  default_unit_label_dict registrations for microgram_per_meter_cubed)
+
 0.9 20231031
 * limit the number of api fields requested from PurpleAir API (thanks to xslima00)
 * switch to using X-API-Key header for PurpleAir API

--- a/install.py
+++ b/install.py
@@ -8,7 +8,7 @@ def loader():
 class PurpleAirMonitorInstaller(ExtensionInstaller):
     def __init__(self):
         super(PurpleAirMonitorInstaller, self).__init__(
-            version="0.4",
+            version="0.10",
             name='purpleair',
             description='Collect Purple Air air quality data.',
             author="Kenneth Baker",


### PR DESCRIPTION
## Summary

- Require weewx 4.0+; raise `UnsupportedFeature` if older.
- Drop redundant unit/format/label registrations for `microgram_per_meter_cubed` — weewx 4.0+ ships `group_concentration → microgram_per_meter_cubed` in `USUnits`/`MetricUnits`/`MetricWXUnits` and the default StringFormat (`%.0f`) and Label (`µg/m³`) in `weewx/defaults.py`.
- Keep the purpleair-specific `obs_group_dict` entries for the `_cf_1` / `_atm` suffixed field names — weewx only knows the unsuffixed `pm1_0` / `pm2_5` / `pm10_0`.
- Bump version to 0.10 in `bin/user/purpleair.py`, `install.py`, and `changelog`.

## Test plan

- [x] `uvx --with requests --with configobj pytest -q` — 8 passed
- [ ] Install on a weewx ≥ 4.0 station, confirm a skin's `[Units][[StringFormats]] microgram_per_meter_cubed = %.1f` is honored on `$current.pm2_5_cf_1.formatted` and on ImageGenerator chart labels.
- [ ] Install attempt on weewx 3.x fails fast with the version check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)